### PR TITLE
feat(auth): JWT 기반 회원가입 및 로그인 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,9 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+    // Spring Security
+    implementation 'org.springframework.boot:spring-boot-starter-security'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,11 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // JWT
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/taskflow/config/SecurityConfig.java
+++ b/src/main/java/com/example/taskflow/config/SecurityConfig.java
@@ -1,0 +1,36 @@
+package com.example.taskflow.config;
+
+import com.example.taskflow.domain.auth.util.JwtFilter;
+import com.example.taskflow.domain.auth.util.JwtProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtProvider jwtProvider;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .sessionManagement(session -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                )
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/api/auth/login", "/api/auth/register").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .addFilterBefore(new JwtFilter(jwtProvider), UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/example/taskflow/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/taskflow/domain/auth/controller/AuthController.java
@@ -6,6 +6,7 @@ import com.example.taskflow.domain.auth.dto.request.AuthRegisterRequest;
 import com.example.taskflow.domain.auth.dto.response.AuthLoginResponse;
 import com.example.taskflow.domain.auth.dto.response.AuthResponse;
 import com.example.taskflow.domain.auth.service.AuthInternalService;
+import jakarta.validation.Valid;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -23,7 +24,7 @@ public class AuthController {
 
     @PostMapping("/register")
     public ResponseEntity<ApiResponse<AuthResponse>> signup(
-            @RequestBody AuthRegisterRequest request
+            @Valid @RequestBody AuthRegisterRequest request
     ) {
         AuthResponse response = authInternalService.signup(request);
 

--- a/src/main/java/com/example/taskflow/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/taskflow/domain/auth/controller/AuthController.java
@@ -20,10 +20,10 @@ public class AuthController {
     private final AuthInternalService authInternalService;
 
     @PostMapping("/register")
-    public ResponseEntity<ApiResponse<AuthResponse>> signUp(
+    public ResponseEntity<ApiResponse<AuthResponse>> signup(
             @RequestBody AuthRegisterRequest registerRequest
     ) {
-        AuthResponse response = authInternalService.signUp(registerRequest);
+        AuthResponse response = authInternalService.signup(registerRequest);
 
         return ApiResponse.created(response, "회원가입이 완료되었습니다.");
     }

--- a/src/main/java/com/example/taskflow/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/taskflow/domain/auth/controller/AuthController.java
@@ -21,9 +21,9 @@ public class AuthController {
 
     @PostMapping("/register")
     public ResponseEntity<ApiResponse<AuthResponse>> signup(
-            @RequestBody AuthRegisterRequest registerRequest
+            @RequestBody AuthRegisterRequest request
     ) {
-        AuthResponse response = authInternalService.signup(registerRequest);
+        AuthResponse response = authInternalService.signup(request);
 
         return ApiResponse.created(response, "회원가입이 완료되었습니다.");
     }

--- a/src/main/java/com/example/taskflow/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/taskflow/domain/auth/controller/AuthController.java
@@ -1,0 +1,17 @@
+package com.example.taskflow.domain.auth.controller;
+
+import com.example.taskflow.domain.auth.service.AuthInternalService;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+@RequestMapping("/api/auth")
+public class AuthController {
+
+    private final AuthInternalService authInternalService;
+
+
+}

--- a/src/main/java/com/example/taskflow/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/taskflow/domain/auth/controller/AuthController.java
@@ -1,8 +1,14 @@
 package com.example.taskflow.domain.auth.controller;
 
+import com.example.taskflow.common.response.ApiResponse;
+import com.example.taskflow.domain.auth.dto.request.AuthRegisterRequest;
+import com.example.taskflow.domain.auth.dto.response.AuthResponse;
 import com.example.taskflow.domain.auth.service.AuthInternalService;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -13,5 +19,12 @@ public class AuthController {
 
     private final AuthInternalService authInternalService;
 
+    @PostMapping("/register")
+    public ResponseEntity<ApiResponse<AuthResponse>> signUp(
+            @RequestBody AuthRegisterRequest registerRequest
+    ) {
+        AuthResponse response = authInternalService.signUp(registerRequest);
 
+        return ApiResponse.created(response, "회원가입이 완료되었습니다.");
+    }
 }

--- a/src/main/java/com/example/taskflow/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/taskflow/domain/auth/controller/AuthController.java
@@ -1,7 +1,9 @@
 package com.example.taskflow.domain.auth.controller;
 
 import com.example.taskflow.common.response.ApiResponse;
+import com.example.taskflow.domain.auth.dto.request.AuthLoginRequest;
 import com.example.taskflow.domain.auth.dto.request.AuthRegisterRequest;
+import com.example.taskflow.domain.auth.dto.response.AuthLoginResponse;
 import com.example.taskflow.domain.auth.dto.response.AuthResponse;
 import com.example.taskflow.domain.auth.service.AuthInternalService;
 import lombok.AccessLevel;
@@ -26,5 +28,14 @@ public class AuthController {
         AuthResponse response = authInternalService.signup(request);
 
         return ApiResponse.created(response, "회원가입이 완료되었습니다.");
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<ApiResponse<AuthLoginResponse>> login(
+            @RequestBody AuthLoginRequest request
+    ) {
+        AuthLoginResponse response = authInternalService.login(request);
+
+        return ApiResponse.created(response, "로그인이 완료되었습니다.");
     }
 }

--- a/src/main/java/com/example/taskflow/domain/auth/dto/request/AuthLoginRequest.java
+++ b/src/main/java/com/example/taskflow/domain/auth/dto/request/AuthLoginRequest.java
@@ -1,0 +1,6 @@
+package com.example.taskflow.domain.auth.dto.request;
+
+public record AuthLoginRequest(
+        String username,
+        String password
+) {}

--- a/src/main/java/com/example/taskflow/domain/auth/dto/request/AuthRegisterRequest.java
+++ b/src/main/java/com/example/taskflow/domain/auth/dto/request/AuthRegisterRequest.java
@@ -1,8 +1,20 @@
 package com.example.taskflow.domain.auth.dto.request;
 
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
 public record AuthRegisterRequest(
+        @Size(min = 4, max = 20)
+        @Pattern(regexp = "^[a-zA-Z0-9]*$")
         String username,
+
+        @Email
         String email,
+
+        @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*()_+\\[\\]{};':\"\\\\|,.<>/?]).{8,}$")
         String password,
+
+        @Size(min = 2, max = 50)
         String name
 ) {}

--- a/src/main/java/com/example/taskflow/domain/auth/dto/request/AuthRegisterRequest.java
+++ b/src/main/java/com/example/taskflow/domain/auth/dto/request/AuthRegisterRequest.java
@@ -1,0 +1,8 @@
+package com.example.taskflow.domain.auth.dto.request;
+
+public record AuthRegisterRequest(
+        String username,
+        String email,
+        String password,
+        String name
+) {}

--- a/src/main/java/com/example/taskflow/domain/auth/dto/response/AuthLoginResponse.java
+++ b/src/main/java/com/example/taskflow/domain/auth/dto/response/AuthLoginResponse.java
@@ -1,0 +1,9 @@
+package com.example.taskflow.domain.auth.dto.response;
+
+public record AuthLoginResponse(
+        String token
+) {
+    public static AuthLoginResponse of(String token) {
+        return new AuthLoginResponse(token);
+    }
+}

--- a/src/main/java/com/example/taskflow/domain/auth/dto/response/AuthResponse.java
+++ b/src/main/java/com/example/taskflow/domain/auth/dto/response/AuthResponse.java
@@ -1,4 +1,25 @@
 package com.example.taskflow.domain.auth.dto.response;
 
-public class AuthResponse {
+import com.example.taskflow.domain.user.entity.User;
+
+import java.time.LocalDateTime;
+
+public record AuthResponse(
+        Long id,
+        String username,
+        String email,
+        String name,
+        String role,
+        LocalDateTime createdAt
+) {
+    public static AuthResponse from(User user) {
+        return new AuthResponse(
+                user.getId(),
+                user.getUsername(),
+                user.getEmail(),
+                user.getName(),
+                String.valueOf(user.getRole()),
+                user.getCreatedAt()
+        );
+    }
 }

--- a/src/main/java/com/example/taskflow/domain/auth/dto/response/AuthResponse.java
+++ b/src/main/java/com/example/taskflow/domain/auth/dto/response/AuthResponse.java
@@ -1,0 +1,4 @@
+package com.example.taskflow.domain.auth.dto.response;
+
+public class AuthResponse {
+}

--- a/src/main/java/com/example/taskflow/domain/auth/exception/AuthErrorCode.java
+++ b/src/main/java/com/example/taskflow/domain/auth/exception/AuthErrorCode.java
@@ -9,7 +9,11 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum AuthErrorCode implements ErrorCode {
 
-    USERNAME_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 존재하는 사용자명입니다");
+    USERNAME_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 존재하는 사용자명입니다"),
+    INVALID_LOGIN(HttpStatus.UNAUTHORIZED, "잘못된 사용자명 또는 비밀번호입니다"),
+    TOKEN_MISSING(HttpStatus.UNAUTHORIZED, "인증이 필요합니다"),
+    TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/example/taskflow/domain/auth/exception/AuthErrorCode.java
+++ b/src/main/java/com/example/taskflow/domain/auth/exception/AuthErrorCode.java
@@ -10,6 +10,7 @@ import org.springframework.http.HttpStatus;
 public enum AuthErrorCode implements ErrorCode {
 
     USERNAME_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 존재하는 사용자명입니다"),
+    EMAIL_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 존재하는 이메일입니다"),
     INVALID_LOGIN(HttpStatus.UNAUTHORIZED, "잘못된 사용자명 또는 비밀번호입니다"),
     TOKEN_MISSING(HttpStatus.UNAUTHORIZED, "인증이 필요합니다"),
     TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다."),

--- a/src/main/java/com/example/taskflow/domain/auth/exception/AuthErrorCode.java
+++ b/src/main/java/com/example/taskflow/domain/auth/exception/AuthErrorCode.java
@@ -1,0 +1,16 @@
+package com.example.taskflow.domain.auth.exception;
+
+import com.example.taskflow.common.exception.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum AuthErrorCode implements ErrorCode {
+
+    USERNAME_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 존재하는 사용자명입니다");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/example/taskflow/domain/auth/exception/AuthException.java
+++ b/src/main/java/com/example/taskflow/domain/auth/exception/AuthException.java
@@ -1,0 +1,10 @@
+package com.example.taskflow.domain.auth.exception;
+
+import com.example.taskflow.common.exception.ErrorCode;
+import com.example.taskflow.common.exception.GlobalException;
+
+public class AuthException extends GlobalException {
+    public AuthException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/example/taskflow/domain/auth/repository/AuthRepository.java
+++ b/src/main/java/com/example/taskflow/domain/auth/repository/AuthRepository.java
@@ -9,4 +9,6 @@ public interface AuthRepository extends JpaRepository<User, Long> {
     boolean existsByUsername(String username);
 
     Optional<User> findByUsername(String username);
+
+    boolean existsByEmail(String email);
 }

--- a/src/main/java/com/example/taskflow/domain/auth/repository/AuthRepository.java
+++ b/src/main/java/com/example/taskflow/domain/auth/repository/AuthRepository.java
@@ -4,4 +4,5 @@ import com.example.taskflow.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface AuthRepository extends JpaRepository<User, Long> {
+    boolean existsByUsername(String username);
 }

--- a/src/main/java/com/example/taskflow/domain/auth/repository/AuthRepository.java
+++ b/src/main/java/com/example/taskflow/domain/auth/repository/AuthRepository.java
@@ -3,6 +3,10 @@ package com.example.taskflow.domain.auth.repository;
 import com.example.taskflow.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface AuthRepository extends JpaRepository<User, Long> {
     boolean existsByUsername(String username);
+
+    Optional<User> findByUsername(String username);
 }

--- a/src/main/java/com/example/taskflow/domain/auth/repository/AuthRepository.java
+++ b/src/main/java/com/example/taskflow/domain/auth/repository/AuthRepository.java
@@ -1,0 +1,7 @@
+package com.example.taskflow.domain.auth.repository;
+
+import com.example.taskflow.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AuthRepository extends JpaRepository<User, Long> {
+}

--- a/src/main/java/com/example/taskflow/domain/auth/service/AuthInternalService.java
+++ b/src/main/java/com/example/taskflow/domain/auth/service/AuthInternalService.java
@@ -1,6 +1,12 @@
 package com.example.taskflow.domain.auth.service;
 
+import com.example.taskflow.domain.auth.dto.request.AuthRegisterRequest;
+import com.example.taskflow.domain.auth.dto.response.AuthResponse;
+import com.example.taskflow.domain.auth.exception.AuthErrorCode;
+import com.example.taskflow.domain.auth.exception.AuthException;
 import com.example.taskflow.domain.auth.repository.AuthRepository;
+import com.example.taskflow.domain.user.entity.User;
+import com.example.taskflow.domain.user.enums.Role;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -10,4 +16,25 @@ import org.springframework.stereotype.Service;
 public class AuthInternalService {
 
     private final AuthRepository authRepository;
+
+    public AuthResponse signUp(AuthRegisterRequest request) {
+
+        if (authRepository.existsByUsername(request.username())) {
+            throw new AuthException(AuthErrorCode.USERNAME_ALREADY_EXISTS);
+        }
+
+        // TODO: 비밀번호 인코딩
+
+        User user = User.create(
+                request.username(),
+                request.password(),
+                request.email(),
+                request.name(),
+                Role.user
+        );
+
+        User savedUser = authRepository.save(user);
+
+        return AuthResponse.from(savedUser);
+    }
 }

--- a/src/main/java/com/example/taskflow/domain/auth/service/AuthInternalService.java
+++ b/src/main/java/com/example/taskflow/domain/auth/service/AuthInternalService.java
@@ -13,9 +13,8 @@ import com.example.taskflow.domain.user.enums.Role;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.ObjectUtils;
-
-import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
@@ -24,6 +23,7 @@ public class AuthInternalService {
     private final AuthRepository authRepository;
     private final JwtProvider jwtProvider;
 
+    @Transactional
     public AuthResponse signup(AuthRegisterRequest request) {
 
         if (authRepository.existsByUsername(request.username())) {
@@ -45,6 +45,7 @@ public class AuthInternalService {
         return AuthResponse.from(savedUser);
     }
 
+    @Transactional
     public AuthLoginResponse login(AuthLoginRequest request) {
         User user = authRepository.findByUsername(request.username()).orElseThrow(() ->
                 new AuthException(AuthErrorCode.INVALID_LOGIN));

--- a/src/main/java/com/example/taskflow/domain/auth/service/AuthInternalService.java
+++ b/src/main/java/com/example/taskflow/domain/auth/service/AuthInternalService.java
@@ -30,6 +30,10 @@ public class AuthInternalService {
             throw new AuthException(AuthErrorCode.USERNAME_ALREADY_EXISTS);
         }
 
+        if (authRepository.existsByEmail(request.email())) {
+            throw new AuthException(AuthErrorCode.EMAIL_ALREADY_EXISTS);
+        }
+
         // TODO: 비밀번호 인코딩
 
         User user = User.create(

--- a/src/main/java/com/example/taskflow/domain/auth/service/AuthInternalService.java
+++ b/src/main/java/com/example/taskflow/domain/auth/service/AuthInternalService.java
@@ -1,21 +1,28 @@
 package com.example.taskflow.domain.auth.service;
 
+import com.example.taskflow.domain.auth.dto.request.AuthLoginRequest;
 import com.example.taskflow.domain.auth.dto.request.AuthRegisterRequest;
+import com.example.taskflow.domain.auth.dto.response.AuthLoginResponse;
 import com.example.taskflow.domain.auth.dto.response.AuthResponse;
 import com.example.taskflow.domain.auth.exception.AuthErrorCode;
 import com.example.taskflow.domain.auth.exception.AuthException;
 import com.example.taskflow.domain.auth.repository.AuthRepository;
+import com.example.taskflow.domain.auth.util.JwtProvider;
 import com.example.taskflow.domain.user.entity.User;
 import com.example.taskflow.domain.user.enums.Role;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.util.ObjectUtils;
+
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public class AuthInternalService {
 
     private final AuthRepository authRepository;
+    private final JwtProvider jwtProvider;
 
     public AuthResponse signup(AuthRegisterRequest request) {
 
@@ -36,5 +43,18 @@ public class AuthInternalService {
         User savedUser = authRepository.save(user);
 
         return AuthResponse.from(savedUser);
+    }
+
+    public AuthLoginResponse login(AuthLoginRequest request) {
+        User user = authRepository.findByUsername(request.username()).orElseThrow(() ->
+                new AuthException(AuthErrorCode.INVALID_LOGIN));
+
+        if (!ObjectUtils.nullSafeEquals(user.getPassword(), request.password())) {
+            throw new AuthException(AuthErrorCode.INVALID_LOGIN);
+        }
+
+        String token = jwtProvider.createToken(user.getId(), user.getEmail(), user.getRole());
+
+        return AuthLoginResponse.of(token);
     }
 }

--- a/src/main/java/com/example/taskflow/domain/auth/service/AuthInternalService.java
+++ b/src/main/java/com/example/taskflow/domain/auth/service/AuthInternalService.java
@@ -17,7 +17,7 @@ public class AuthInternalService {
 
     private final AuthRepository authRepository;
 
-    public AuthResponse signUp(AuthRegisterRequest request) {
+    public AuthResponse signup(AuthRegisterRequest request) {
 
         if (authRepository.existsByUsername(request.username())) {
             throw new AuthException(AuthErrorCode.USERNAME_ALREADY_EXISTS);

--- a/src/main/java/com/example/taskflow/domain/auth/service/AuthInternalService.java
+++ b/src/main/java/com/example/taskflow/domain/auth/service/AuthInternalService.java
@@ -1,0 +1,13 @@
+package com.example.taskflow.domain.auth.service;
+
+import com.example.taskflow.domain.auth.repository.AuthRepository;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public class AuthInternalService {
+
+    private final AuthRepository authRepository;
+}

--- a/src/main/java/com/example/taskflow/domain/auth/util/JwtFilter.java
+++ b/src/main/java/com/example/taskflow/domain/auth/util/JwtFilter.java
@@ -1,16 +1,26 @@
 package com.example.taskflow.domain.auth.util;
 
+import com.example.taskflow.common.exception.ErrorCode;
+import com.example.taskflow.common.response.ApiResponse;
+import com.example.taskflow.domain.auth.exception.AuthException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.util.PatternMatchUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
 
 @RequiredArgsConstructor
 public class JwtFilter extends OncePerRequestFilter {
@@ -32,16 +42,34 @@ public class JwtFilter extends OncePerRequestFilter {
             return;
         }
 
-        String token = jwtProvider.resolveToken(request);
-        jwtProvider.validateToken(token);
+        try {
+            String token = jwtProvider.resolveToken(request);
+            jwtProvider.validateToken(token);
 
-        Authentication authentication = jwtProvider.getAuthentication(token);
-        SecurityContextHolder.getContext().setAuthentication(authentication);
+            Authentication authentication = jwtProvider.getAuthentication(token);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
 
-        filterChain.doFilter(request, response);
+            filterChain.doFilter(request, response);
+        } catch (AuthException e) {
+            sendErrorResponse(response, e.getErrorCode(), e.getMessage());
+        }
     }
 
     private boolean isWhiteList(String url) {
         return PatternMatchUtils.simpleMatch(WHITELIST, url);
+    }
+
+    private void sendErrorResponse(HttpServletResponse response, ErrorCode errorCode, String message) throws IOException {
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        response.setStatus(errorCode.getHttpStatus().value());
+
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule());
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+        ApiResponse<Object> body = ApiResponse.error(errorCode);
+
+        response.getWriter().write(mapper.writeValueAsString(body));
     }
 }

--- a/src/main/java/com/example/taskflow/domain/auth/util/JwtFilter.java
+++ b/src/main/java/com/example/taskflow/domain/auth/util/JwtFilter.java
@@ -1,11 +1,5 @@
 package com.example.taskflow.domain.auth.util;
 
-import com.example.taskflow.domain.auth.exception.AuthErrorCode;
-import com.example.taskflow.domain.auth.exception.AuthException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import io.jsonwebtoken.ExpiredJwtException;
-import io.jsonwebtoken.MalformedJwtException;
-import io.jsonwebtoken.UnsupportedJwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -22,7 +16,6 @@ import java.io.IOException;
 public class JwtFilter extends OncePerRequestFilter {
 
     private final JwtProvider jwtProvider;
-    private final ObjectMapper objectMapper;
 
     private static String[] WHITELIST = {
             "/api/auth/register",

--- a/src/main/java/com/example/taskflow/domain/auth/util/JwtFilter.java
+++ b/src/main/java/com/example/taskflow/domain/auth/util/JwtFilter.java
@@ -1,0 +1,54 @@
+package com.example.taskflow.domain.auth.util;
+
+import com.example.taskflow.domain.auth.exception.AuthErrorCode;
+import com.example.taskflow.domain.auth.exception.AuthException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.PatternMatchUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class JwtFilter extends OncePerRequestFilter {
+
+    private final JwtProvider jwtProvider;
+    private final ObjectMapper objectMapper;
+
+    private static String[] WHITELIST = {
+            "/api/auth/register",
+            "/api/auth/login"
+    };
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+
+        String url = request.getRequestURI();
+
+        if (isWhiteList(url)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String token = jwtProvider.resolveToken(request);
+        jwtProvider.validateToken(token);
+
+        Authentication authentication = jwtProvider.getAuthentication(token);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        filterChain.doFilter(request, response);
+    }
+
+    private boolean isWhiteList(String url) {
+        return PatternMatchUtils.simpleMatch(WHITELIST, url);
+    }
+}

--- a/src/main/java/com/example/taskflow/domain/auth/util/JwtProvider.java
+++ b/src/main/java/com/example/taskflow/domain/auth/util/JwtProvider.java
@@ -1,17 +1,24 @@
 package com.example.taskflow.domain.auth.util;
 
+import com.example.taskflow.domain.auth.exception.AuthErrorCode;
+import com.example.taskflow.domain.auth.exception.AuthException;
 import com.example.taskflow.domain.user.enums.Role;
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
 
 import java.security.Key;
 import java.util.Base64;
 import java.util.Date;
 
+import static org.springframework.security.core.authority.AuthorityUtils.createAuthorityList;
+
+@Slf4j
 @Component
 public class JwtProvider {
 
@@ -50,6 +57,57 @@ public class JwtProvider {
     }
 
     /**
+     * 토큰으로부터 받은 정보를 기반으로 Authentication 객체 반환
+     *
+     * @param token
+     * @return Authentication
+     */
+    public Authentication getAuthentication(String token) {
+        return new UsernamePasswordAuthenticationToken(
+                getUserId(token),
+                null,
+                createAuthorityList(getRole(token))
+        );
+    }
+
+    /**
+     * 요청 헤더의 'Authorization' 필드에서 토큰 추출
+     *
+     * @param request
+     * @return 토큰 문자열
+     */
+    public String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+
+        if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+
+        throw new AuthException(AuthErrorCode.TOKEN_MISSING);
+    }
+
+    /**
+     * 토큰 정보 검증
+     *
+     * @param token
+     * @return
+     */
+    public void validateToken(String token) {
+        try {
+             Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(token);
+        } catch (ExpiredJwtException e) {
+            throw new AuthException(AuthErrorCode.TOKEN_EXPIRED);
+        } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
+            throw new AuthException(AuthErrorCode.INVALID_TOKEN);
+        } catch (UnsupportedJwtException | IllegalArgumentException e) {
+            throw new AuthException(AuthErrorCode.INVALID_TOKEN);
+        }
+    }
+
+    /**
      * JWT 토큰에서 Claims 추출
      *
      * @param token JWT 문자열
@@ -61,5 +119,40 @@ public class JwtProvider {
                 .build()
                 .parseClaimsJws(token)
                 .getBody();
+    }
+
+    /**
+     * Token에서 User ID 추출
+     *
+     * @param token
+     * @return User ID
+     */
+    public Long getUserId(String token) {
+        return Long.parseLong(
+                extractClaims(token)
+                        .getSubject()
+        );
+    }
+
+    /**
+     * Token에서 Email 추출
+     *
+     * @param token
+     * @return Email
+     */
+    public String getEmail(String token) {
+        return extractClaims(token)
+                .get("email", String.class);
+    }
+
+    /**
+     * Token에서 Role 추출
+     *
+     * @param token
+     * @return Role
+     */
+    public String getRole(String token) {
+        return extractClaims(token)
+                .get("role", String.class);
     }
 }

--- a/src/main/java/com/example/taskflow/domain/auth/util/JwtProvider.java
+++ b/src/main/java/com/example/taskflow/domain/auth/util/JwtProvider.java
@@ -1,0 +1,65 @@
+package com.example.taskflow.domain.auth.util;
+
+import com.example.taskflow.domain.user.enums.Role;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Base64;
+import java.util.Date;
+
+@Component
+public class JwtProvider {
+
+    private final Key key;
+    private final long EXPIRE_TIME;
+    private final SignatureAlgorithm signatureAlgorithm = SignatureAlgorithm.HS256;
+
+    public JwtProvider(
+            @Value("${jwt.secret.key}") String secretKey,
+            @Value("${jwt.token.expire-time}") long expireTime
+    ) {
+        byte[] bytes = Base64.getDecoder().decode(secretKey);
+        this.key = Keys.hmacShaKeyFor(bytes);
+        this.EXPIRE_TIME = expireTime;
+    }
+
+    /**
+     * JWT 토큰 생성
+     *
+     * @param userId 사용자 ID
+     * @param email 사용자 이메일
+     * @param role 사용자 역할(Role Enum)
+     * @return JWT 토큰 문자열
+     */
+    public String createToken(Long userId, String email, Role role) {
+        Date date = new Date();
+
+        return Jwts.builder()
+                        .setSubject(String.valueOf(userId))
+                        .claim("email", email)
+                        .claim("role", role.name())
+                        .setExpiration(new Date(date.getTime() + EXPIRE_TIME))
+                        .setIssuedAt(date)
+                        .signWith(key, signatureAlgorithm)
+                        .compact();
+    }
+
+    /**
+     * JWT 토큰에서 Claims 추출
+     *
+     * @param token JWT 문자열
+     * @return Claims 객첸
+     */
+    public Claims extractClaims(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,3 +15,9 @@ spring:
       hibernate:
         show_sql: true
         format_sql: true
+
+jwt:
+  secret:
+    key: ${JWT_SECRET_KEY}
+  token:
+    expire-time: ${JWT_EXPIRE_TIME}


### PR DESCRIPTION
## 작업 내용
### 1.  회원가입 및 로그인 API 구현
 -  `POST /auth/signup`
 -  `POST /auth/login`

### 2. JWT 토큰 발급 및 검증
- 의존성 추가 (Gradle)
```gradle
// JWT
implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'

// Spring Security
implementation 'org.springframework.boot:spring-boot-starter-security'
```
 - yml 설정
```yaml
jwt:
  secret:
    key: ${JWT_SECRET_KEY}
  token:
    expire-time: ${JWT_EXPIRE_TIME}
```
- `.env` 예시
```
JWT_SECRET_KEY= # 시크릿 키는 팀 노션에서 확인
JWT_EXPIRE_TIME=86400000
```
- 토큰 정보: userId, email, role
- 만료시간:  24시간
- Postman 테스트 시 Authorization 헤더에 Bearer {{token}} 포함
- 로그인 후 자동 토큰 적용 스크립트
   - Postman 환경변수 `token`에 토큰 저장
``` javascript
let jsonData = pm.response.json();
pm.environment.set("token", jsonData.data.token);
```
---

## 개선 사항
- 비밀번호 암호화 추가
- 필터 체인 설정을 통해 불필요한 화이트리스트 제거
- 토큰 만료 시간 AccessToken / RefreshToken 분리

## 개발 예정
-  `@AuthenticationPrincipal`로 사용자 정보 접근 지원

---
### 참고사항
- `@NoArgsConstructor(access = AccessLevel.PROTECTED)` 설정으로 인해 User 엔티티에서 정적 메서드를 사용
- 테스트 완료
