### PR TITLE
feat(auth): @CurrentUser 커스텀 어노테이션/리졸버 구현

### DIFF
--- a/src/main/java/com/example/taskflow/config/SecurityConfig.java
+++ b/src/main/java/com/example/taskflow/config/SecurityConfig.java
@@ -1,7 +1,7 @@
 package com.example.taskflow.config;
 
-import com.example.taskflow.domain.auth.util.JwtFilter;
-import com.example.taskflow.domain.auth.util.JwtProvider;
+import com.example.taskflow.domain.auth.security.JwtFilter;
+import com.example.taskflow.domain.auth.security.JwtProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/com/example/taskflow/config/WebMvcConfig.java
+++ b/src/main/java/com/example/taskflow/config/WebMvcConfig.java
@@ -1,0 +1,21 @@
+package com.example.taskflow.config;
+
+import com.example.taskflow.domain.auth.security.AuthUserArgumentResolver;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    private final AuthUserArgumentResolver authUserArgumentResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(authUserArgumentResolver);
+    }
+}

--- a/src/main/java/com/example/taskflow/domain/auth/dto/request/AuthWithdrawRequest.java
+++ b/src/main/java/com/example/taskflow/domain/auth/dto/request/AuthWithdrawRequest.java
@@ -1,0 +1,5 @@
+package com.example.taskflow.domain.auth.dto.request;
+
+public record AuthWithdrawRequest (
+        String password
+) {}

--- a/src/main/java/com/example/taskflow/domain/auth/exception/AuthErrorCode.java
+++ b/src/main/java/com/example/taskflow/domain/auth/exception/AuthErrorCode.java
@@ -14,7 +14,8 @@ public enum AuthErrorCode implements ErrorCode {
     INVALID_LOGIN(HttpStatus.UNAUTHORIZED, "잘못된 사용자명 또는 비밀번호입니다"),
     TOKEN_MISSING(HttpStatus.UNAUTHORIZED, "인증이 필요합니다"),
     TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다."),
-    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다.");
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
+    INVALID_AUTHENTICATION(HttpStatus.UNAUTHORIZED, "인증 정보가 없거나 유효하지 않습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/example/taskflow/domain/auth/security/AuthUser.java
+++ b/src/main/java/com/example/taskflow/domain/auth/security/AuthUser.java
@@ -1,0 +1,43 @@
+package com.example.taskflow.domain.auth.security;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+
+/**
+ *  Spring Security에서 사용하는 UserDetails 구현체
+ *
+ *  AuthUserDto를 기반으로 Security 객체 생성
+ *  JWT 인증/권한 검증 시 사용
+ */
+@Getter
+@AllArgsConstructor
+public class AuthUser implements UserDetails {
+
+    private AuthUserDto authUserDto;
+    private Collection<GrantedAuthority> authorities;
+
+    @Override
+    public String getPassword() {
+        return authUserDto.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return authUserDto.getUsername();
+    }
+
+    /**
+     * 사용자의 권한 목록 반환
+     *
+     * @return
+     */
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return authorities;
+    }
+}

--- a/src/main/java/com/example/taskflow/domain/auth/security/AuthUserArgumentResolver.java
+++ b/src/main/java/com/example/taskflow/domain/auth/security/AuthUserArgumentResolver.java
@@ -37,6 +37,8 @@ public class AuthUserArgumentResolver implements HandlerMethodArgumentResolver {
             throw new AuthException(AuthErrorCode.INVALID_AUTHENTICATION);
         }
 
-        return authentication.getPrincipal();
+        AuthUser authUser = (AuthUser) authentication.getPrincipal();
+
+        return authUser.getAuthUserDto().getId();
     }
 }

--- a/src/main/java/com/example/taskflow/domain/auth/security/AuthUserArgumentResolver.java
+++ b/src/main/java/com/example/taskflow/domain/auth/security/AuthUserArgumentResolver.java
@@ -1,0 +1,42 @@
+package com.example.taskflow.domain.auth.security;
+
+import com.example.taskflow.domain.auth.exception.AuthErrorCode;
+import com.example.taskflow.domain.auth.exception.AuthException;
+import com.example.taskflow.domain.auth.security.annotation.CurrentUser;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import java.util.Objects;
+
+@Component
+public class AuthUserArgumentResolver implements HandlerMethodArgumentResolver {
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        boolean hasAuthUserAnnotation = parameter.getParameterAnnotation(CurrentUser.class) != null;
+        boolean isLongType = Long.class.equals(parameter.getParameterType());
+
+        return hasAuthUserAnnotation && isLongType;
+    }
+
+    @Override
+    public Object resolveArgument(
+            MethodParameter parameter,
+            ModelAndViewContainer mavContainer,
+            NativeWebRequest webRequest,
+            WebDataBinderFactory binderFactory
+    ) throws Exception {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (Objects.isNull(authentication)) {
+            throw new AuthException(AuthErrorCode.INVALID_AUTHENTICATION);
+        }
+
+        return authentication.getPrincipal();
+    }
+}

--- a/src/main/java/com/example/taskflow/domain/auth/security/AuthUserDetailsService.java
+++ b/src/main/java/com/example/taskflow/domain/auth/security/AuthUserDetailsService.java
@@ -1,0 +1,44 @@
+package com.example.taskflow.domain.auth.security;
+
+import com.example.taskflow.common.exception.CommonErrorCode;
+import com.example.taskflow.domain.auth.exception.AuthException;
+import com.example.taskflow.domain.auth.repository.AuthRepository;
+import com.example.taskflow.domain.user.entity.User;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+
+@Service("userDetailsService")
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public class AuthUserDetailsService implements UserDetailsService {
+
+    private final AuthRepository authRepository;
+
+    /**
+     * username으로 사용자 조회 후 SecurityUserDetails 객체 반환
+     *
+     * @param username
+     * @return
+     * @throws UsernameNotFoundException
+     */
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        User user = authRepository.findByUsername(username).orElseThrow(()
+                -> new AuthException(CommonErrorCode.INVALID_USER));
+
+        AuthUserDto authUserDto = AuthUserDto.from(user);
+
+        return new AuthUser(
+                authUserDto,
+                Collections.singleton(
+                        new SimpleGrantedAuthority(authUserDto.getRole().toString())
+                )
+        );
+    }
+}

--- a/src/main/java/com/example/taskflow/domain/auth/security/AuthUserDto.java
+++ b/src/main/java/com/example/taskflow/domain/auth/security/AuthUserDto.java
@@ -1,0 +1,32 @@
+package com.example.taskflow.domain.auth.security;
+
+import com.example.taskflow.domain.user.entity.User;
+import com.example.taskflow.domain.user.enums.Role;
+import lombok.Getter;
+
+@Getter
+public class AuthUserDto {
+    private final Long id;
+    private final String username;
+    private final String password;
+    private final String email;
+    private final Role role;
+
+    private AuthUserDto(Long id, String username, String password, String email, Role role) {
+        this.id = id;
+        this.username = username;
+        this.password = password;
+        this.email = email;
+        this.role = role;
+    }
+
+    public static AuthUserDto from(User user) {
+        return new AuthUserDto(
+                user.getId(),
+                user.getUsername(),
+                user.getPassword(),
+                user.getEmail(),
+                user.getRole()
+        );
+    }
+}

--- a/src/main/java/com/example/taskflow/domain/auth/security/JwtAuthUserService.java
+++ b/src/main/java/com/example/taskflow/domain/auth/security/JwtAuthUserService.java
@@ -7,29 +7,18 @@ import com.example.taskflow.domain.user.entity.User;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.core.userdetails.UserDetailsService;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
 import java.util.Collections;
 
-@Service("userDetailsService")
+@Service
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
-public class AuthUserDetailsService implements UserDetailsService {
+public class JwtAuthUserService {
 
     private final AuthRepository authRepository;
 
-    /**
-     * username으로 사용자 조회 후 SecurityUserDetails 객체 반환
-     *
-     * @param username
-     * @return
-     * @throws UsernameNotFoundException
-     */
-    @Override
-    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        User user = authRepository.findByUsername(username).orElseThrow(()
+    public AuthUser loadAuthUser(Long userId) {
+        User user = authRepository.findById(userId).orElseThrow(()
                 -> new AuthException(CommonErrorCode.INVALID_USER));
 
         AuthUserDto authUserDto = AuthUserDto.from(user);

--- a/src/main/java/com/example/taskflow/domain/auth/security/JwtFilter.java
+++ b/src/main/java/com/example/taskflow/domain/auth/security/JwtFilter.java
@@ -11,17 +11,13 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.util.PatternMatchUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
-import java.util.Collection;
-import java.util.Collections;
 
 @RequiredArgsConstructor
 public class JwtFilter extends OncePerRequestFilter {

--- a/src/main/java/com/example/taskflow/domain/auth/security/JwtFilter.java
+++ b/src/main/java/com/example/taskflow/domain/auth/security/JwtFilter.java
@@ -11,12 +11,17 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.util.PatternMatchUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
 
 @RequiredArgsConstructor
 public class JwtFilter extends OncePerRequestFilter {

--- a/src/main/java/com/example/taskflow/domain/auth/security/JwtFilter.java
+++ b/src/main/java/com/example/taskflow/domain/auth/security/JwtFilter.java
@@ -1,4 +1,4 @@
-package com.example.taskflow.domain.auth.util;
+package com.example.taskflow.domain.auth.security;
 
 import com.example.taskflow.common.exception.ErrorCode;
 import com.example.taskflow.common.response.ApiResponse;
@@ -11,16 +11,12 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.util.PatternMatchUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
-import java.time.LocalDateTime;
-import java.util.HashMap;
-import java.util.Map;
 
 @RequiredArgsConstructor
 public class JwtFilter extends OncePerRequestFilter {

--- a/src/main/java/com/example/taskflow/domain/auth/security/JwtProvider.java
+++ b/src/main/java/com/example/taskflow/domain/auth/security/JwtProvider.java
@@ -7,6 +7,7 @@ import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -25,6 +26,9 @@ public class JwtProvider {
     private final Key key;
     private final long EXPIRE_TIME;
     private final SignatureAlgorithm signatureAlgorithm = SignatureAlgorithm.HS256;
+
+    @Autowired
+    private JwtAuthUserService jwtAuthUserService;
 
     public JwtProvider(
             @Value("${jwt.secret.key}") String secretKey,
@@ -63,8 +67,12 @@ public class JwtProvider {
      * @return Authentication
      */
     public Authentication getAuthentication(String token) {
+        Long userId = getUserId(token);
+
+        AuthUser authUser = jwtAuthUserService.loadAuthUser(userId);
+
         return new UsernamePasswordAuthenticationToken(
-                getUserId(token),
+                authUser,
                 null,
                 createAuthorityList(getRole(token))
         );

--- a/src/main/java/com/example/taskflow/domain/auth/security/JwtProvider.java
+++ b/src/main/java/com/example/taskflow/domain/auth/security/JwtProvider.java
@@ -1,4 +1,4 @@
-package com.example.taskflow.domain.auth.util;
+package com.example.taskflow.domain.auth.security;
 
 import com.example.taskflow.domain.auth.exception.AuthErrorCode;
 import com.example.taskflow.domain.auth.exception.AuthException;

--- a/src/main/java/com/example/taskflow/domain/auth/security/annotation/CurrentUser.java
+++ b/src/main/java/com/example/taskflow/domain/auth/security/annotation/CurrentUser.java
@@ -1,0 +1,11 @@
+package com.example.taskflow.domain.auth.security.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CurrentUser {
+}

--- a/src/main/java/com/example/taskflow/domain/auth/service/AuthInternalService.java
+++ b/src/main/java/com/example/taskflow/domain/auth/service/AuthInternalService.java
@@ -7,7 +7,7 @@ import com.example.taskflow.domain.auth.dto.response.AuthResponse;
 import com.example.taskflow.domain.auth.exception.AuthErrorCode;
 import com.example.taskflow.domain.auth.exception.AuthException;
 import com.example.taskflow.domain.auth.repository.AuthRepository;
-import com.example.taskflow.domain.auth.util.JwtProvider;
+import com.example.taskflow.domain.auth.security.JwtProvider;
 import com.example.taskflow.domain.user.entity.User;
 import com.example.taskflow.domain.user.enums.Role;
 import lombok.AccessLevel;


### PR DESCRIPTION
## 작업 내용
- `@CurrentUser` 커스텀 어노테이션 및 ArgumentResolver 구현
- Authentication에서 `AuthUser` 정보를 받아 리졸버에서 `userId` 추출
- JWT 및 Security 관련 클래스 패키지 구조 리팩토링

<br>

## 개선 사항 
-  요구사항에 정의된 `@AuthenticationPrincipal` 사용 시 컨트롤러에서 `UserDetails` 객체를 직접 처리해야 함 
  → 책임이 컨트롤러로 분산
  → 가독성 및 사용에 복잡함이 있다고 판단하여 커스텀 어노테이션 개발로 방향 변경
- 커스텀 어노테이션(`@CurrentUser`)과 ArgumentResolver 적용 
  - 컨트롤러에서는 **ID나 필요한 정보만 간편하게 주입** 가능  
  - Security 관련 로직과 컨트롤러 로직 분리 
- 향후 확장성 고려: 필요한 경우 `AuthUser` 전체를 반환하도록도 손쉽게 변경 가능
<br>

## 개발(작업) 예정

- 로그아웃, 회원탈퇴 CRUD

<br>

### 참고 사항
- `@CurrentUser` 사용 예시
```java
@PostMapping("/withdraw")
    public ResponseEntity<ApiResponse<AuthResponse>> withdraw(
            @RequestBody AuthWithdrawRequest request,
            @CurrentUser Long userId
    ) {
        AuthResponse response = authInternalService.withdraw(request, userId);

        return ApiResponse.created(null, "회원탈퇴가 완료되었습니다.");
    }
```
- 테스트 완료
