### PR TITLE
Feat/user search

### DIFF
--- a/src/main/java/com/example/taskflow/domain/search/controller/SearchController.java
+++ b/src/main/java/com/example/taskflow/domain/search/controller/SearchController.java
@@ -1,12 +1,10 @@
 package com.example.taskflow.domain.search.controller;
 
-import com.example.taskflow.common.exception.GlobalException;
 import com.example.taskflow.common.response.ApiResponse;
 import com.example.taskflow.domain.search.dto.SearchResult;
 import com.example.taskflow.domain.search.exception.SearchErrorCode;
 import com.example.taskflow.domain.search.exception.SearchException;
 import com.example.taskflow.domain.search.service.SearchService;
-import com.example.taskflow.domain.user.exception.UserErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;

--- a/src/main/java/com/example/taskflow/domain/search/controller/SearchController.java
+++ b/src/main/java/com/example/taskflow/domain/search/controller/SearchController.java
@@ -1,8 +1,12 @@
 package com.example.taskflow.domain.search.controller;
 
+import com.example.taskflow.common.exception.GlobalException;
 import com.example.taskflow.common.response.ApiResponse;
 import com.example.taskflow.domain.search.dto.SearchResult;
+import com.example.taskflow.domain.search.exception.SearchErrorCode;
+import com.example.taskflow.domain.search.exception.SearchException;
 import com.example.taskflow.domain.search.service.SearchService;
+import com.example.taskflow.domain.user.exception.UserErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -23,6 +27,10 @@ public class SearchController {
      */
     @GetMapping
     public ResponseEntity<ApiResponse<SearchResult>> search(@RequestParam("q") String query) {
+        if (query == null || query.trim().isEmpty()) {
+            throw new SearchException(SearchErrorCode.EMPTY_QUERY);
+        }
+
         SearchResult result = searchService.searchAll(query);
         return ApiResponse.success(result, "검색 완료");
     }

--- a/src/main/java/com/example/taskflow/domain/search/exception/SearchErrorCode.java
+++ b/src/main/java/com/example/taskflow/domain/search/exception/SearchErrorCode.java
@@ -1,0 +1,16 @@
+package com.example.taskflow.domain.search.exception;
+
+import com.example.taskflow.common.exception.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum SearchErrorCode implements ErrorCode {
+
+    EMPTY_QUERY(HttpStatus.BAD_REQUEST, "검색어를 입력해주세요.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/example/taskflow/domain/search/exception/SearchException.java
+++ b/src/main/java/com/example/taskflow/domain/search/exception/SearchException.java
@@ -1,0 +1,10 @@
+package com.example.taskflow.domain.search.exception;
+
+import com.example.taskflow.common.exception.ErrorCode;
+import com.example.taskflow.common.exception.GlobalException;
+
+public class SearchException extends GlobalException {
+    public SearchException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/example/taskflow/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/taskflow/domain/user/controller/UserController.java
@@ -1,6 +1,7 @@
 package com.example.taskflow.domain.user.controller;
 
 import com.example.taskflow.common.response.ApiResponse;
+import com.example.taskflow.domain.auth.security.annotation.CurrentUser;
 import com.example.taskflow.domain.user.dto.UserResponse;
 import com.example.taskflow.domain.user.service.UserInternalService;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/example/taskflow/domain/user/entity/User.java
+++ b/src/main/java/com/example/taskflow/domain/user/entity/User.java
@@ -50,6 +50,10 @@ public class User extends BaseEntity {
         this.role = role;
     }
 
+    public static User create(String username, String password, String email, String name, Role role) {
+        return new User(username, password, email, name, role);
+    }
+
     public void setDeletedAt(LocalDateTime deletedAt) {
         this.deletedAt = deletedAt;
     }

--- a/src/main/java/com/example/taskflow/domain/user/service/UserExternalService.java
+++ b/src/main/java/com/example/taskflow/domain/user/service/UserExternalService.java
@@ -1,10 +1,10 @@
 package com.example.taskflow.domain.user.service;
 
 
-import com.example.taskflow.common.exception.GlobalException;
 import com.example.taskflow.domain.search.dto.UserSummary;
 import com.example.taskflow.domain.user.exception.UserErrorCode;
 import com.example.taskflow.domain.user.entity.User;
+import com.example.taskflow.domain.user.exception.UserException;
 import com.example.taskflow.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -24,7 +24,7 @@ public class UserExternalService {
     // 1. 단일 유저 조회 (탈퇴한 유저 제외)
     public User getUserById(Long id) {
         return userRepository.findByIdAndDeletedAtIsNull(id)
-                .orElseThrow(() -> new GlobalException(UserErrorCode.USER_NOT_FOUND));
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
     }
 
     // 2. 여러 유저 조회 (탈퇴한 유저 제외)
@@ -33,7 +33,7 @@ public class UserExternalService {
         List<User> users = userRepository.findActiveUsersByTeamId(teamId);
 
         if (users.isEmpty()) {
-            throw new GlobalException(UserErrorCode.USER_NOT_FOUND);
+            throw new UserException(UserErrorCode.USER_NOT_FOUND);
         }
 
         return users;

--- a/src/main/java/com/example/taskflow/domain/user/service/UserExternalService.java
+++ b/src/main/java/com/example/taskflow/domain/user/service/UserExternalService.java
@@ -22,7 +22,7 @@ public class UserExternalService {
 
 
     // 1. 단일 유저 조회 (탈퇴한 유저 제외)
-    public User getFindById(Long id) {
+    public User getUserById(Long id) {
         return userRepository.findByIdAndDeletedAtIsNull(id)
                 .orElseThrow(() -> new GlobalException(UserErrorCode.USER_NOT_FOUND));
     }

--- a/src/main/java/com/example/taskflow/domain/user/service/UserInternalService.java
+++ b/src/main/java/com/example/taskflow/domain/user/service/UserInternalService.java
@@ -18,7 +18,7 @@ import java.util.List;
 public class UserInternalService {
 
     private final UserRepository userRepository;
-//    private final TeamExternalService teamExternalService;
+    private final TeamExternalService teamExternalService;
 
     // 1. 현재 로그인한 사용자 정보 조회
     public UserResponse getMyInfo(Long userId) {
@@ -53,8 +53,7 @@ public class UserInternalService {
     // 4. 팀에 추가 가능한 사용자 목록 조회
     public List<UserResponse> getSelectableUsers(Long teamId) {
         if (teamId != null) {
-//            팀 검증 포함할 시 (TeamExternalService에 코드 추가 필요)
-//            teamExternalService.requireExisting(teamId);
+            teamExternalService.getTeamById(teamId);
             return getUsersNotInTeam(teamId);
         }
 

--- a/src/main/java/com/example/taskflow/domain/user/service/UserInternalService.java
+++ b/src/main/java/com/example/taskflow/domain/user/service/UserInternalService.java
@@ -24,7 +24,7 @@ public class UserInternalService {
     public UserResponse getMyInfo(Long userId) {
 
         User user = userRepository.findByIdAndDeletedAtIsNull(userId)
-                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+                .orElseThrow(() -> new UserException(UserErrorCode.UNAUTHORIZED));
 
         return UserResponse.from(user);
     }


### PR DESCRIPTION
## 작업 내용

- SearchController에서 검색어 미입력 시 EMPTY_QUERY 에러 응답 추가
- UserExternalService에서 단일 유저 조회 메서드명을 getFindById → getUserById로 변경
- UserInternalService에서 현재 로그인 사용자 조회 시 예외 응답을 USER_NOT_FOUND → UNAUTHORIZED로 변경
- User 엔티티에 정적 팩토리 메서드 create() 추가
- UserInternalService에서 팀에 추가 가능한 사용자 조회 시 teamId 존재 검증 로직 추가

<br>

## 개선 사항 

- 도메인별 예외 응답의 일관성 강화
- 불필요한 예외 중복 방지 및 책임 분리를 위해 팀 존재 여부 검증을 UserInternalService에서 명확히 수행하도록 개선

