### PR TITLE
feat(auth): JWT Access/Refresh 토큰 분리 및 로그아웃 기능 구현

### DIFF
--- a/src/main/java/com/example/taskflow/config/SecurityConfig.java
+++ b/src/main/java/com/example/taskflow/config/SecurityConfig.java
@@ -18,7 +18,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @RequiredArgsConstructor
 public class SecurityConfig {
 
-    private final JwtProvider jwtProvider;
+    private final JwtFilter jwtFilter;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -31,7 +31,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/auth/login", "/api/auth/register").permitAll()
                         .anyRequest().authenticated()
                 )
-                .addFilterBefore(new JwtFilter(jwtProvider), UsernamePasswordAuthenticationFilter.class);
+                .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/java/com/example/taskflow/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/taskflow/domain/auth/controller/AuthController.java
@@ -43,6 +43,15 @@ public class AuthController {
         return ApiResponse.created(response, "로그인이 완료되었습니다.");
     }
 
+    @PostMapping("/logout")
+    public ResponseEntity<ApiResponse<AuthResponse>> logout(
+            @CurrentUser Long user
+    ) {
+        authInternalService.logout(user);
+
+        return ApiResponse.deleteSuccess("로그아웃이 완료되었습니다.");
+    }
+
     @PostMapping("/withdraw")
     public ResponseEntity<ApiResponse<AuthResponse>> withdraw(
             @RequestBody AuthWithdrawRequest request,

--- a/src/main/java/com/example/taskflow/domain/auth/dto/response/TokenResponse.java
+++ b/src/main/java/com/example/taskflow/domain/auth/dto/response/TokenResponse.java
@@ -1,0 +1,7 @@
+package com.example.taskflow.domain.auth.dto.response;
+
+public record TokenResponse(String accessToken, String refreshToken, long refreshTime) {
+    public static TokenResponse of(String accessToken, String refreshToken, long refreshTime) {
+        return new TokenResponse(accessToken, refreshToken, refreshTime);
+    }
+}

--- a/src/main/java/com/example/taskflow/domain/auth/entity/RefreshToken.java
+++ b/src/main/java/com/example/taskflow/domain/auth/entity/RefreshToken.java
@@ -1,0 +1,53 @@
+package com.example.taskflow.domain.auth.entity;
+
+import com.example.taskflow.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "refresh_token")
+public class RefreshToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false, unique = true)
+    private User user;
+
+    @Column(nullable = false, unique = true)
+    private String token;
+
+    @Column(nullable = false)
+    private LocalDateTime expireAt;
+
+    private RefreshToken(User user, String token, LocalDateTime expireAt) {
+        this.user = user;
+        this.token = token;
+        this.expireAt = expireAt;
+    }
+
+    public static RefreshToken create(User user, String token, long expireMillis) {
+        return new RefreshToken(
+                user,
+                token,
+                LocalDateTime.now().plusNanos(expireMillis * 1_000_000)
+        );
+    }
+
+    public boolean isExpired() {
+        return LocalDateTime.now().isAfter(expireAt);
+    }
+
+    public void updateToken(String newToken, long expireMillis) {
+        this.token = newToken;
+        this.expireAt = LocalDateTime.now().plusNanos(expireMillis * 1_000_000);
+    }
+}

--- a/src/main/java/com/example/taskflow/domain/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/example/taskflow/domain/auth/repository/RefreshTokenRepository.java
@@ -1,0 +1,10 @@
+package com.example.taskflow.domain.auth.repository;
+
+import com.example.taskflow.domain.auth.entity.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+    Optional<RefreshToken> findByUserId(Long id);
+}

--- a/src/main/java/com/example/taskflow/domain/auth/security/JwtFilter.java
+++ b/src/main/java/com/example/taskflow/domain/auth/security/JwtFilter.java
@@ -2,7 +2,11 @@ package com.example.taskflow.domain.auth.security;
 
 import com.example.taskflow.common.exception.ErrorCode;
 import com.example.taskflow.common.response.ApiResponse;
+import com.example.taskflow.domain.auth.entity.RefreshToken;
+import com.example.taskflow.domain.auth.exception.AuthErrorCode;
 import com.example.taskflow.domain.auth.exception.AuthException;
+import com.example.taskflow.domain.auth.service.TokenInternalService;
+import com.example.taskflow.domain.user.enums.Role;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
@@ -11,6 +15,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.core.Authentication;
 
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -19,10 +24,12 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 
+@Configuration
 @RequiredArgsConstructor
 public class JwtFilter extends OncePerRequestFilter {
 
     private final JwtProvider jwtProvider;
+    private final TokenInternalService tokenInternalService;
 
     private static String[] WHITELIST = {
             "/api/auth/register",
@@ -41,7 +48,19 @@ public class JwtFilter extends OncePerRequestFilter {
 
         try {
             String token = jwtProvider.resolveToken(request);
-            jwtProvider.validateToken(token);
+
+            try {
+                jwtProvider.validateAccessToken(token);
+            } catch (AuthException e) {
+                if (e.getErrorCode() == AuthErrorCode.TOKEN_EXPIRED) {
+                    token = handleExpiredAccessToken(token, response);
+                } else {
+                    throw e;
+                }
+            }
+
+            Long userId = jwtProvider.getUserIdAllowExpired(token);
+            tokenInternalService.findValidRefreshToken(userId);
 
             Authentication authentication = jwtProvider.getAuthentication(token);
             SecurityContextHolder.getContext().setAuthentication(authentication);
@@ -49,7 +68,28 @@ public class JwtFilter extends OncePerRequestFilter {
             filterChain.doFilter(request, response);
         } catch (AuthException e) {
             sendErrorResponse(response, e.getErrorCode(), e.getMessage());
+        } catch (IOException e) {
+            sendErrorResponse(response, AuthErrorCode.TOKEN_EXPIRED, e.getMessage());
         }
+    }
+
+    /**
+     * Access Token 만료 시 Refresh Token 검증 후 새 Access Token 발급
+     *
+     * @param expiredToken
+     * @param response
+     * @return
+     */
+    private String handleExpiredAccessToken(String expiredToken, HttpServletResponse response) {
+        Long userId = jwtProvider.getUserIdAllowExpired(expiredToken);
+
+        // 로그아웃 체크
+        tokenInternalService.findValidRefreshToken(userId);
+
+        String newToken = jwtProvider.refreshAccessToken(expiredToken);
+        response.setHeader("Authorization", "Bearer " + newToken);
+
+        return newToken;
     }
 
     private boolean isWhiteList(String url) {

--- a/src/main/java/com/example/taskflow/domain/auth/security/JwtProvider.java
+++ b/src/main/java/com/example/taskflow/domain/auth/security/JwtProvider.java
@@ -1,5 +1,6 @@
 package com.example.taskflow.domain.auth.security;
 
+import com.example.taskflow.domain.auth.dto.response.TokenResponse;
 import com.example.taskflow.domain.auth.exception.AuthErrorCode;
 import com.example.taskflow.domain.auth.exception.AuthException;
 import com.example.taskflow.domain.user.enums.Role;
@@ -7,7 +8,6 @@ import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -24,41 +24,92 @@ import static org.springframework.security.core.authority.AuthorityUtils.createA
 public class JwtProvider {
 
     private final Key key;
-    private final long EXPIRE_TIME;
+    private final long ACCESS_EXPIRE_TIME;  // Access Token 만료 시간 (밀리초)
+    private final long REFRESH_EXPIRE_TIME; // Refresh Token 만료 시간 (밀리초)
     private final SignatureAlgorithm signatureAlgorithm = SignatureAlgorithm.HS256;
 
-    @Autowired
-    private JwtAuthUserService jwtAuthUserService;
+    private final JwtAuthUserService jwtAuthUserService;
 
+    /**
+     * JWT Provider 생성자
+     *
+     * @param secretKey
+     * @param accessTime
+     * @param refreshTime
+     * @param jwtAuthUserService
+     */
     public JwtProvider(
             @Value("${jwt.secret.key}") String secretKey,
-            @Value("${jwt.token.expire-time}") long expireTime
+            @Value("${jwt.token.access-expire-time}") long accessTime,
+            @Value("${jwt.token.refresh-expire-time}") long refreshTime,
+            JwtAuthUserService jwtAuthUserService
     ) {
         byte[] bytes = Base64.getDecoder().decode(secretKey);
         this.key = Keys.hmacShaKeyFor(bytes);
-        this.EXPIRE_TIME = expireTime;
+        this.ACCESS_EXPIRE_TIME = accessTime;
+        this.REFRESH_EXPIRE_TIME = refreshTime;
+        this.jwtAuthUserService = jwtAuthUserService;
     }
 
     /**
-     * JWT 토큰 생성
+     * 로그인 시 Access Token과 Refresh Token 발급
+     *
+     * - Access Token: API 호출 시 사용, 클라이언트로 반환
+     * - Refresh Token: Redis에 저장, Access Token 재발급 시 사용
      *
      * @param userId 사용자 ID
      * @param email 사용자 이메일
-     * @param role 사용자 역할(Role Enum)
-     * @return JWT 토큰 문자열
+     * @param role 사용자 권한(Role Enum)
+     * @return Access Token 문자열
      */
-    public String createToken(Long userId, String email, Role role) {
-        Date date = new Date();
+    public TokenResponse createToken(Long userId, String email, Role role) {
+        long now = (new Date()).getTime();
 
-        return Jwts.builder()
-                        .setSubject(String.valueOf(userId))
-                        .claim("email", email)
-                        .claim("role", role.name())
-                        .setExpiration(new Date(date.getTime() + EXPIRE_TIME))
-                        .setIssuedAt(date)
-                        .signWith(key, signatureAlgorithm)
-                        .compact();
+        // Access Token 생성
+        Date accessTokenExpire = new Date(now + ACCESS_EXPIRE_TIME);
+        String accessToken = createAccessToken(userId, email, role, accessTokenExpire);
+
+        // Refresh Token 생성
+        Date refreshTokenExpire = new Date(now + REFRESH_EXPIRE_TIME);
+        String refreshToken = createRefreshToken(userId, refreshTokenExpire);
+
+        return TokenResponse.of(accessToken, refreshToken, REFRESH_EXPIRE_TIME);
     }
+
+    /**
+     * Access Token 생성
+     *
+     * @param userId
+     * @param email
+     * @param role
+     * @param expireDate
+     * @return
+     */
+    private String createAccessToken(Long userId, String email, Role role, Date expireDate) {
+        return Jwts.builder()
+                .setSubject(String.valueOf(userId))
+                .claim("email", email)
+                .claim("role", role.name())
+                .setExpiration(expireDate)
+                .signWith(key, signatureAlgorithm)
+                .compact();
+    }
+
+    /**
+     * Refresh Token 생성
+     *
+     * @param userId
+     * @param expireDate
+     * @return
+     */
+    private String createRefreshToken(Long userId, Date expireDate) {
+        return Jwts.builder()
+                .setSubject(String.valueOf(userId))
+                .setExpiration(expireDate)
+                .signWith(key, signatureAlgorithm)
+                .compact();
+    }
+
 
     /**
      * 토큰으로부터 받은 정보를 기반으로 Authentication 객체 반환
@@ -96,6 +147,10 @@ public class JwtProvider {
 
     /**
      * 토큰 정보 검증
+     *
+     * - 유효하지 않은 토큰
+     * - 만료된 토큰
+     * - 블랙리스트에 있는 토큰
      *
      * @param token
      * @return

--- a/src/main/java/com/example/taskflow/domain/auth/security/JwtProvider.java
+++ b/src/main/java/com/example/taskflow/domain/auth/security/JwtProvider.java
@@ -110,6 +110,26 @@ public class JwtProvider {
                 .compact();
     }
 
+    public String refreshAccessToken(String token) {
+        Claims claims = extractClaimsAllowExpired(token);
+        Long userId = Long.parseLong(claims.getSubject());
+        String email = claims.get("email", String.class);
+        Role role = Role.valueOf(claims.get("role", String.class));
+
+        long now = (new Date()).getTime();
+        Date newExpire = new Date(now + ACCESS_EXPIRE_TIME);
+        return createAccessToken(userId, email, role, newExpire);
+    }
+
+    public void validateAccessToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+        } catch (ExpiredJwtException e) {
+            throw new AuthException(AuthErrorCode.TOKEN_EXPIRED);
+        } catch (SecurityException | MalformedJwtException | UnsupportedJwtException | IllegalArgumentException e) {
+            throw new AuthException(AuthErrorCode.INVALID_TOKEN);
+        }
+    }
 
     /**
      * 토큰으로부터 받은 정보를 기반으로 Authentication 객체 반환
@@ -182,6 +202,27 @@ public class JwtProvider {
                 .build()
                 .parseClaimsJws(token)
                 .getBody();
+    }
+
+    public Claims extractClaimsAllowExpired(String token) {
+        try {
+            // 정상 토큰이면 그대로
+            return Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+        } catch (ExpiredJwtException e) {
+            // 만료된 토큰이라도 Claims는 반환
+            return e.getClaims();
+        } catch (JwtException e) {
+            // 다른 유효하지 않은 토큰
+            throw new AuthException(AuthErrorCode.INVALID_TOKEN);
+        }
+    }
+
+    public Long getUserIdAllowExpired(String token) {
+        return Long.parseLong(extractClaimsAllowExpired(token).getSubject());
     }
 
     /**

--- a/src/main/java/com/example/taskflow/domain/auth/service/AuthInternalService.java
+++ b/src/main/java/com/example/taskflow/domain/auth/service/AuthInternalService.java
@@ -6,10 +6,11 @@ import com.example.taskflow.domain.auth.dto.request.AuthRegisterRequest;
 import com.example.taskflow.domain.auth.dto.request.AuthWithdrawRequest;
 import com.example.taskflow.domain.auth.dto.response.AuthLoginResponse;
 import com.example.taskflow.domain.auth.dto.response.AuthResponse;
+import com.example.taskflow.domain.auth.dto.response.TokenResponse;
+import com.example.taskflow.domain.auth.entity.RefreshToken;
 import com.example.taskflow.domain.auth.exception.AuthErrorCode;
 import com.example.taskflow.domain.auth.exception.AuthException;
 import com.example.taskflow.domain.auth.repository.AuthRepository;
-import com.example.taskflow.domain.auth.security.JwtProvider;
 import com.example.taskflow.domain.user.entity.User;
 import com.example.taskflow.domain.user.enums.Role;
 import lombok.AccessLevel;
@@ -25,8 +26,8 @@ import java.time.LocalDateTime;
 public class AuthInternalService {
 
     private final AuthRepository authRepository;
-    private final JwtProvider jwtProvider;
     private final PasswordEncoder passwordEncoder;
+    private final TokenInternalService tokenInternalService;
 
     @Transactional
     public AuthResponse signup(AuthRegisterRequest request) {
@@ -54,7 +55,7 @@ public class AuthInternalService {
         return AuthResponse.from(savedUser);
     }
 
-    @Transactional(readOnly = true)
+    @Transactional
     public AuthLoginResponse login(AuthLoginRequest request) {
         User user = authRepository.findByUsernameAndDeletedAtIsNull(request.username()).orElseThrow(() ->
                 new AuthException(AuthErrorCode.USER_WITHDRAWN));
@@ -63,9 +64,9 @@ public class AuthInternalService {
             throw new AuthException(AuthErrorCode.INVALID_LOGIN);
         }
 
-        String token = jwtProvider.createToken(user.getId(), user.getEmail(), user.getRole());
+        String accessToken = tokenInternalService.generateOrUpdateTokens(user);
 
-        return AuthLoginResponse.of(token);
+        return AuthLoginResponse.of(accessToken);
     }
 
     @Transactional

--- a/src/main/java/com/example/taskflow/domain/auth/service/AuthInternalService.java
+++ b/src/main/java/com/example/taskflow/domain/auth/service/AuthInternalService.java
@@ -70,6 +70,11 @@ public class AuthInternalService {
     }
 
     @Transactional
+    public void logout(Long userId) {
+        tokenInternalService.logout(userId);
+    }
+
+    @Transactional
     public void withdraw(AuthWithdrawRequest request, Long userId) {
 
         User user = authRepository.findById(userId).orElseThrow(

--- a/src/main/java/com/example/taskflow/domain/auth/service/AuthInternalService.java
+++ b/src/main/java/com/example/taskflow/domain/auth/service/AuthInternalService.java
@@ -47,7 +47,7 @@ public class AuthInternalService {
                 encodePw,
                 request.email(),
                 request.name(),
-                Role.user
+                Role.USER
         );
 
         User savedUser = authRepository.save(user);

--- a/src/main/java/com/example/taskflow/domain/auth/service/TokenInternalService.java
+++ b/src/main/java/com/example/taskflow/domain/auth/service/TokenInternalService.java
@@ -2,6 +2,8 @@ package com.example.taskflow.domain.auth.service;
 
 import com.example.taskflow.domain.auth.dto.response.TokenResponse;
 import com.example.taskflow.domain.auth.entity.RefreshToken;
+import com.example.taskflow.domain.auth.exception.AuthErrorCode;
+import com.example.taskflow.domain.auth.exception.AuthException;
 import com.example.taskflow.domain.auth.repository.RefreshTokenRepository;
 import com.example.taskflow.domain.auth.security.JwtProvider;
 import com.example.taskflow.domain.user.entity.User;
@@ -38,5 +40,25 @@ public class TokenInternalService {
         }
 
         return token.accessToken();
+    }
+
+    @Transactional
+    public void logout(Long userId) {
+        refreshTokenRepository.findByUserId(userId)
+                .ifPresent(refreshTokenRepository::delete);
+    }
+
+    @Transactional(readOnly = true)
+    public RefreshToken findValidRefreshToken(Long userId) {
+        return refreshTokenRepository.findByUserId(userId)
+                .filter(token -> !token.isExpired())
+                .orElseThrow(() -> new AuthException(AuthErrorCode.TOKEN_EXPIRED));
+    }
+
+    @Transactional(readOnly = true)
+    public boolean hasRefreshToken(Long userId) {
+        return refreshTokenRepository.findByUserId(userId)
+                .map(token -> !token.isExpired())
+                .orElse(false);
     }
 }

--- a/src/main/java/com/example/taskflow/domain/auth/service/TokenInternalService.java
+++ b/src/main/java/com/example/taskflow/domain/auth/service/TokenInternalService.java
@@ -1,0 +1,42 @@
+package com.example.taskflow.domain.auth.service;
+
+import com.example.taskflow.domain.auth.dto.response.TokenResponse;
+import com.example.taskflow.domain.auth.entity.RefreshToken;
+import com.example.taskflow.domain.auth.repository.RefreshTokenRepository;
+import com.example.taskflow.domain.auth.security.JwtProvider;
+import com.example.taskflow.domain.user.entity.User;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public class TokenInternalService {
+
+    private final JwtProvider jwtProvider;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    /**
+     * 로그인 성공 시 Access Token과 Refresh Token 생성 또는 갱신
+     *
+     * @param user 로그인한 User 엔티티
+     * @return 발급된 Access Token
+     */
+    @Transactional
+    public String generateOrUpdateTokens(User user) {
+        TokenResponse token = jwtProvider.createToken(user.getId(), user.getEmail(), user.getRole());
+
+        RefreshToken existingToken = refreshTokenRepository.findByUserId(user.getId()).orElse(null);
+
+        if (existingToken != null) {
+            existingToken.updateToken(token.refreshToken(), token.refreshTime());
+        } else {
+            refreshTokenRepository.save(
+                    RefreshToken.create(user, token.refreshToken(), token.refreshTime())
+            );
+        }
+
+        return token.accessToken();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,4 +20,5 @@ jwt:
   secret:
     key: ${JWT_SECRET_KEY}
   token:
-    expire-time: ${JWT_EXPIRE_TIME}
+    access-expire-time: ${JWT_ACCESS_TOKEN_EXPIRE:3600000}
+    refresh-expire-time: ${JWT_REFRESH_TOKEN_EXPIRE:86400000}


### PR DESCRIPTION
## 작업 내용

- 기존 단일 토큰에서 **Access Token / Refresh Token 분리**  
  - Access Token: 짧은 유효기간, API 인증용  (1시간)  
  - Refresh Token: 긴 유효기간, Access Token 재발급용  (24시간) 
- 로그아웃 시 **Refresh Token 삭제** 및 서버 측 토큰 무효화 처리  
- 프론트 요청 시 Access Token 만료 시 **Refresh Token으로 자동 재발급** 가능하도록 구현  


<br>

## 개발(작업) 예정

- 

<br>

### 참고 사항

- 테스트 완료
- User 코드 변경으로 인한 Role 수정
